### PR TITLE
Update demos to use new enums

### DIFF
--- a/notebooks/All About REM Statistics.ipynb
+++ b/notebooks/All About REM Statistics.ipynb
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "cecd5ef2-6a34-4752-9899-fc3fe519c3d9",
    "metadata": {},
    "outputs": [],
@@ -95,13 +95,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "58f2da86-6a32-448d-83a5-ba487e6c54a8",
    "metadata": {},
    "outputs": [],
    "source": [
     "address = '165 Hope St, Providence, RI 02906'\n",
-    "upgrade = \"med_eff_hp_hers_sizing_no_setback\"\n",
+    "upgrade = \"hvac__heat_pump_seer18_hspf10\"\n",
     "heating_fuel = 'fuel_oil'"
    ]
   },
@@ -115,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "2aa2f974-6382-45db-9b8a-bc127873f924",
    "metadata": {},
    "outputs": [],
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "064bddb1-9644-44d3-96de-4d7a070e2772",
    "metadata": {},
    "outputs": [
@@ -143,7 +143,7 @@
        "<Response [200]>"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -164,7 +164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "90889101-3961-4c23-841c-f6bfb994cee1",
    "metadata": {},
    "outputs": [],
@@ -174,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "048c58b4-7071-4a74-b273-8e877f6240a3",
    "metadata": {},
    "outputs": [],
@@ -184,28 +184,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "053ed56b",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'energy': {'mean': {'value': 1896.4884, 'units': 'gallon'},\n",
-       "  'median': {'value': 1835.3018, 'units': 'gallon'},\n",
-       "  'percentile_20': {'value': 1421.099, 'units': 'gallon'},\n",
-       "  'percentile_80': {'value': 2339.4446, 'units': 'gallon'}},\n",
-       " 'emissions': {'mean': {'value': 23339.9604, 'units': 'kgCO2e'},\n",
-       "  'median': {'value': 22586.9408, 'units': 'kgCO2e'},\n",
-       "  'percentile_20': {'value': 17489.3729, 'units': 'kgCO2e'},\n",
-       "  'percentile_80': {'value': 28791.3938, 'units': 'kgCO2e'}},\n",
-       " 'cost': {'mean': {'value': 7583.0636, 'units': '$'},\n",
-       "  'median': {'value': 7338.4104, 'units': '$'},\n",
-       "  'percentile_20': {'value': 5682.2301, 'units': '$'},\n",
-       "  'percentile_80': {'value': 9354.2134, 'units': '$'}}}"
+       "{'energy': {'mean': {'value': 1605.7854, 'units': 'gallon'},\n",
+       "  'median': {'value': 1522.1593, 'units': 'gallon'},\n",
+       "  'percentile_20': {'value': 1193.7379, 'units': 'gallon'},\n",
+       "  'percentile_80': {'value': 2003.3473, 'units': 'gallon'}},\n",
+       " 'emissions': {'mean': {'value': 19762.2968, 'units': 'kgCO2e'},\n",
+       "  'median': {'value': 18733.1155, 'units': 'kgCO2e'},\n",
+       "  'percentile_20': {'value': 14691.2552, 'units': 'kgCO2e'},\n",
+       "  'percentile_80': {'value': 24655.0653, 'units': 'kgCO2e'}},\n",
+       " 'cost': {'mean': {'value': 6420.6944, 'units': '$'},\n",
+       "  'median': {'value': 6086.3173, 'units': '$'},\n",
+       "  'percentile_20': {'value': 4773.1325, 'units': '$'},\n",
+       "  'percentile_80': {'value': 8010.3361, 'units': '$'}}}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -216,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "6bafae54",
    "metadata": {},
    "outputs": [
@@ -229,7 +229,7 @@
        " 'propane': {'value': 7.3776, 'units': 'kgCO2e/gallon'}}"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -251,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "04ddef09-134c-4734-a932-1d698b268345",
    "metadata": {},
    "outputs": [],
@@ -261,52 +261,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "f859af3b-7dd1-45f0-81e5-9377aed86b1e",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'baseline': {'energy': {'mean': {'value': 1896.4884, 'units': 'gallon'},\n",
-       "   'median': {'value': 1835.3018, 'units': 'gallon'},\n",
-       "   'percentile_20': {'value': 1421.099, 'units': 'gallon'},\n",
-       "   'percentile_80': {'value': 2339.4446, 'units': 'gallon'}},\n",
-       "  'emissions': {'mean': {'value': 23339.9604, 'units': 'kgCO2e'},\n",
-       "   'median': {'value': 22586.9408, 'units': 'kgCO2e'},\n",
-       "   'percentile_20': {'value': 17489.3729, 'units': 'kgCO2e'},\n",
-       "   'percentile_80': {'value': 28791.3938, 'units': 'kgCO2e'}},\n",
-       "  'cost': {'mean': {'value': 7583.0636, 'units': '$'},\n",
-       "   'median': {'value': 7338.4104, 'units': '$'},\n",
-       "   'percentile_20': {'value': 5682.2301, 'units': '$'},\n",
-       "   'percentile_80': {'value': 9354.2134, 'units': '$'}}},\n",
-       " 'upgrade': {'energy': {'mean': {'value': 66.8291, 'units': 'gallon'},\n",
+       "{'baseline': {'energy': {'mean': {'value': 1605.7854, 'units': 'gallon'},\n",
+       "   'median': {'value': 1522.1593, 'units': 'gallon'},\n",
+       "   'percentile_20': {'value': 1193.7379, 'units': 'gallon'},\n",
+       "   'percentile_80': {'value': 2003.3473, 'units': 'gallon'}},\n",
+       "  'emissions': {'mean': {'value': 19762.2968, 'units': 'kgCO2e'},\n",
+       "   'median': {'value': 18733.1155, 'units': 'kgCO2e'},\n",
+       "   'percentile_20': {'value': 14691.2552, 'units': 'kgCO2e'},\n",
+       "   'percentile_80': {'value': 24655.0653, 'units': 'kgCO2e'}},\n",
+       "  'cost': {'mean': {'value': 6420.6944, 'units': '$'},\n",
+       "   'median': {'value': 6086.3173, 'units': '$'},\n",
+       "   'percentile_20': {'value': 4773.1325, 'units': '$'},\n",
+       "   'percentile_80': {'value': 8010.3361, 'units': '$'}}},\n",
+       " 'upgrade': {'energy': {'mean': {'value': 66.8082, 'units': 'gallon'},\n",
        "   'median': {'value': 0.0, 'units': 'gallon'},\n",
        "   'percentile_20': {'value': 0.0, 'units': 'gallon'},\n",
-       "   'percentile_80': {'value': 127.0023, 'units': 'gallon'}},\n",
-       "  'emissions': {'mean': {'value': 822.4611, 'units': 'kgCO2e'},\n",
+       "   'percentile_80': {'value': 135.0306, 'units': 'gallon'}},\n",
+       "  'emissions': {'mean': {'value': 822.2047, 'units': 'kgCO2e'},\n",
        "   'median': {'value': 0.0, 'units': 'kgCO2e'},\n",
        "   'percentile_20': {'value': 0.0, 'units': 'kgCO2e'},\n",
-       "   'percentile_80': {'value': 1563.0089, 'units': 'kgCO2e'}},\n",
-       "  'cost': {'mean': {'value': 267.2145, 'units': '$'},\n",
+       "   'percentile_80': {'value': 1661.8123, 'units': 'kgCO2e'}},\n",
+       "  'cost': {'mean': {'value': 267.1312, 'units': '$'},\n",
        "   'median': {'value': 0.0, 'units': '$'},\n",
        "   'percentile_20': {'value': 0.0, 'units': '$'},\n",
-       "   'percentile_80': {'value': 507.8156, 'units': '$'}}},\n",
-       " 'delta': {'energy': {'mean': {'value': -1829.6594, 'units': 'gallon'},\n",
-       "   'median': {'value': -1734.66, 'units': 'gallon'},\n",
-       "   'percentile_20': {'value': -2254.9817, 'units': 'gallon'},\n",
-       "   'percentile_80': {'value': -1351.139, 'units': 'gallon'}},\n",
-       "  'emissions': {'mean': {'value': -22517.4993, 'units': 'kgCO2e'},\n",
-       "   'median': {'value': -21348.3478, 'units': 'kgCO2e'},\n",
-       "   'percentile_20': {'value': -27751.9135, 'units': 'kgCO2e'},\n",
-       "   'percentile_80': {'value': -16628.3804, 'units': 'kgCO2e'}},\n",
-       "  'cost': {'mean': {'value': -7315.8491, 'units': '$'},\n",
-       "   'median': {'value': -6935.9963, 'units': '$'},\n",
-       "   'percentile_20': {'value': -9016.4902, 'units': '$'},\n",
-       "   'percentile_80': {'value': -5402.497, 'units': '$'}}}}"
+       "   'percentile_80': {'value': 539.9164, 'units': '$'}}},\n",
+       " 'delta': {'energy': {'mean': {'value': -1538.9771, 'units': 'gallon'},\n",
+       "   'median': {'value': -1448.375, 'units': 'gallon'},\n",
+       "   'percentile_20': {'value': -1936.0537, 'units': 'gallon'},\n",
+       "   'percentile_80': {'value': -1139.4738, 'units': 'gallon'}},\n",
+       "  'emissions': {'mean': {'value': -18940.0921, 'units': 'kgCO2e'},\n",
+       "   'median': {'value': -17825.0574, 'units': 'kgCO2e'},\n",
+       "   'percentile_20': {'value': -23826.8878, 'units': 'kgCO2e'},\n",
+       "   'percentile_80': {'value': -14023.4303, 'units': 'kgCO2e'}},\n",
+       "  'cost': {'mean': {'value': -6153.5632, 'units': '$'},\n",
+       "   'median': {'value': -5791.2928, 'units': '$'},\n",
+       "   'percentile_20': {'value': -7741.2644, 'units': '$'},\n",
+       "   'percentile_80': {'value': -4556.1587, 'units': '$'}}}}"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -329,7 +329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "6aab1b8e-c3d9-4d0f-a7d4-1a86f1543def",
    "metadata": {},
    "outputs": [
@@ -339,7 +339,7 @@
        "dict_keys(['baseline', 'upgrade', 'delta'])"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -359,7 +359,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "9000390b-3ccf-42dc-b1bd-8df3c67e1a21",
    "metadata": {},
    "outputs": [],
@@ -385,19 +385,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "8ae5239f-0a6b-4838-aa56-a800a8f69fe2",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'baseline': {'value': 1896.4884, 'units': 'gallon'},\n",
-       " 'upgrade': {'value': 66.8291, 'units': 'gallon'},\n",
-       " 'delta': {'value': -1829.6594, 'units': 'gallon'}}"
+       "{'baseline': {'value': 1605.7854, 'units': 'gallon'},\n",
+       " 'upgrade': {'value': 66.8082, 'units': 'gallon'},\n",
+       " 'delta': {'value': -1538.9771, 'units': 'gallon'}}"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -428,17 +428,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "f4a4ad93-2321-4925-a783-691768f23ce9",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.0"
+       "-0.0"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -459,19 +459,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "69e7ded5-6084-4031-906a-5f806b447632",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'baseline': {'value': 1835.3018, 'units': 'gallon'},\n",
+       "{'baseline': {'value': 1522.1593, 'units': 'gallon'},\n",
        " 'upgrade': {'value': 0.0, 'units': 'gallon'},\n",
-       " 'delta': {'value': -1734.66, 'units': 'gallon'}}"
+       " 'delta': {'value': -1448.375, 'units': 'gallon'}}"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -495,7 +495,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "e54eb08e-491b-4f2b-83b3-1fd4901941a5",
    "metadata": {},
    "outputs": [
@@ -505,7 +505,7 @@
        "{'value': 0.0, 'units': 'gallon'}"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -516,17 +516,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "172e005f",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'value': 127.0023, 'units': 'gallon'}"
+       "{'value': 135.0306, 'units': 'gallon'}"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -547,7 +547,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "00facc0b-8037-495a-ae24-451017d0fecf",
    "metadata": {},
    "outputs": [],
@@ -557,7 +557,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "9e391af5-451b-43ef-88fd-572ee62b041c",
    "metadata": {},
    "outputs": [],
@@ -567,19 +567,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "c197ae97-0161-4d3d-8103-13eb9ecdfb5f",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'baseline': {'value': 24494.8882, 'units': 'kgCO2e'},\n",
-       " 'upgrade': {'value': 4827.1306, 'units': 'kgCO2e'},\n",
-       " 'delta': {'value': -19006.6082, 'units': 'kgCO2e'}}"
+       "{'baseline': {'value': 20482.2944, 'units': 'kgCO2e'},\n",
+       " 'upgrade': {'value': 4541.7164, 'units': 'kgCO2e'},\n",
+       " 'delta': {'value': -15580.2861, 'units': 'kgCO2e'}}"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -601,17 +601,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "id": "77f9bbef-5c57-405a-a2c6-6f206c7b499c",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "-661.15"
+       "-360.29"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -643,7 +643,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -657,7 +657,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.13.1"
   }
  },
  "nbformat": 4,

--- a/notebooks/Health Impacts.ipynb
+++ b/notebooks/Health Impacts.ipynb
@@ -5,6 +5,7 @@
    "id": "f9a2131e-ef4d-48a5-85cf-be523964d472",
    "metadata": {},
    "source": [
+    "# TODO: Update this after https://github.com/rewiringamerica/api_demos/pull/8 is merged\n",
     "# Calling the Rewiring America Health Impacts API from Python\n",
     "\n",
     "In December, Rewiring America released our second public API. The API is based on data and models\n",

--- a/notebooks/Health Impacts.ipynb
+++ b/notebooks/Health Impacts.ipynb
@@ -5,7 +5,6 @@
    "id": "f9a2131e-ef4d-48a5-85cf-be523964d472",
    "metadata": {},
    "source": [
-    "# TODO: Update this after https://github.com/rewiringamerica/api_demos/pull/8 is merged\n",
     "# Calling the Rewiring America Health Impacts API from Python\n",
     "\n",
     "In December, Rewiring America released our second public API. The API is based on data and models\n",

--- a/notebooks/REM Demo.ipynb
+++ b/notebooks/REM Demo.ipynb
@@ -71,7 +71,7 @@
    "outputs": [],
    "source": [
     "address = '8009 Belmont Ave., Lubbock, TX 79424'\n",
-    "upgrade = \"high_eff_hp_elec_backup\"\n",
+    "upgrade = \"hvac__heat_pump_seer24_hspf13\"\n",
     "heating_fuel = 'natural_gas'"
    ]
   },

--- a/react/README.md
+++ b/react/README.md
@@ -11,3 +11,14 @@ The only difference is that this version is written in react.
 If you are not already familiar with react, we suggest you have a look
 at the [Tic-Tac-Toe Tutorial](https://react.dev/learn/tutorial-tic-tac-toe),
 which is a great interactive introduction to react.
+
+
+To use, install [Node.js](https://nodejs.org/en/) and run
+```
+npm install
+```
+
+Then run the app with
+```
+npm start
+```

--- a/react/src/App.js
+++ b/react/src/App.js
@@ -18,7 +18,7 @@ function AddressForm() {
     const [savings, setSavings] = useState("")
     const [hidden, setHidden] = useState(true)
 
-    const upgrade = 'high_eff_hp_elec_backup'
+    const upgrade = 'hvac__heat_pump_seer24_hspf13'
 
     // This is the URL for the REM API.
     const remApiURL = "https://api.rewiringamerica.org/api/v1/rem/address"

--- a/rem-with-nextjs/app/serverSavings.ts
+++ b/rem-with-nextjs/app/serverSavings.ts
@@ -30,7 +30,7 @@ const RA_API_KEY = await accessRaApiKey()
 
 export default async function serverSavings(address : string, currentFuel: string) {
 
-    const upgrade = 'high_eff_hp_elec_backup';
+    const upgrade = 'hvac__heat_pump_seer24_hspf13';
 
     // This is the URL for the REM API.
     const remApiURL = "https://api.rewiringamerica.org/api/v1/rem/address";

--- a/www/index.html
+++ b/www/index.html
@@ -36,7 +36,7 @@ on the response it gets.
             const address = document.getElementById("address").value;
             const fuel = document.querySelector('input[name="fuel"]:checked').value;
             const base_url = "https://api.rewiringamerica.org/api/v1/rem/address"
-            const url = encodeURI(base_url + "?upgrade=high_eff_hp_elec_backup&address=" + address + "&heating_fuel=" + fuel) 
+            const url = encodeURI(base_url + "?upgrade=hvac__heat_pump_seer24_hspf13&address=" + address + "&heating_fuel=" + fuel)
             const options = {method: 'GET', accept: "application/json", headers: {Authorization: "Bearer " + api_key}};
             
             console.log("Fetching " + url)


### PR DESCRIPTION
This updates all the demos to use the new upgrade enum strings.

To be merged after the updates to the REM (https://github.com/rewiringamerica/dohyo/pull/103) are merged and released.

**Testing:** I ran all the notebooks and demo apps (by pointing them to the local API with the changes) and made sure they still work. The tests are failing in the Github Action - this is expected until the APIs are updated.

`Health Impacts.ipynb` is being updated in #8.