### PR TITLE
Add examples with water heaters

### DIFF
--- a/notebooks/REM Demo.ipynb
+++ b/notebooks/REM Demo.ipynb
@@ -427,7 +427,7 @@
    "id": "41a4aca4-8ebe-4ff0-9631-ac50f02a791a",
    "metadata": {},
    "source": [
-    "You can optionally set `water_heater_fuel` for other upgrades as well. This can help make the baseline results more accurate, by restricting the modeled homes to those with water heaters fueled in the same way.\n",
+    "You can optionally set `water_heater_fuel` for other upgrades as well. This can help make the results more accurate, by restricting the modeled homes to those with water heaters fueled in the same way.\n",
     "\n",
     "However, if your water heater fuel type is relatively unusual for homes in your area with your heating fuel type, there is a chance the model won't be able to make a good prediction and you'll get an error message.\n",
     "\n",

--- a/notebooks/REM Demo.ipynb
+++ b/notebooks/REM Demo.ipynb
@@ -164,7 +164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "d697ac84",
    "metadata": {},
    "outputs": [],
@@ -190,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "1831a4bd",
    "metadata": {},
    "outputs": [],
@@ -201,10 +201,147 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "cf88eec5",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>metric</th>\n",
+       "      <th>stat</th>\n",
+       "      <th>value</th>\n",
+       "      <th>unit</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>energy</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>818.0488</td>\n",
+       "      <td>therm</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>energy</td>\n",
+       "      <td>median</td>\n",
+       "      <td>773.5015</td>\n",
+       "      <td>therm</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>energy</td>\n",
+       "      <td>percentile_20</td>\n",
+       "      <td>558.5560</td>\n",
+       "      <td>therm</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>energy</td>\n",
+       "      <td>percentile_80</td>\n",
+       "      <td>1023.5165</td>\n",
+       "      <td>therm</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>emissions</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>5464.4159</td>\n",
+       "      <td>kgCO2e</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>emissions</td>\n",
+       "      <td>median</td>\n",
+       "      <td>5166.8484</td>\n",
+       "      <td>kgCO2e</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>emissions</td>\n",
+       "      <td>percentile_20</td>\n",
+       "      <td>3731.0518</td>\n",
+       "      <td>kgCO2e</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>emissions</td>\n",
+       "      <td>percentile_80</td>\n",
+       "      <td>6836.9028</td>\n",
+       "      <td>kgCO2e</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>cost</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>1297.4921</td>\n",
+       "      <td>$</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>cost</td>\n",
+       "      <td>median</td>\n",
+       "      <td>1241.7834</td>\n",
+       "      <td>$</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>cost</td>\n",
+       "      <td>percentile_20</td>\n",
+       "      <td>972.9829</td>\n",
+       "      <td>$</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>cost</td>\n",
+       "      <td>percentile_80</td>\n",
+       "      <td>1554.4402</td>\n",
+       "      <td>$</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       metric           stat      value    unit\n",
+       "0      energy           mean   818.0488   therm\n",
+       "1      energy         median   773.5015   therm\n",
+       "2      energy  percentile_20   558.5560   therm\n",
+       "3      energy  percentile_80  1023.5165   therm\n",
+       "4   emissions           mean  5464.4159  kgCO2e\n",
+       "5   emissions         median  5166.8484  kgCO2e\n",
+       "6   emissions  percentile_20  3731.0518  kgCO2e\n",
+       "7   emissions  percentile_80  6836.9028  kgCO2e\n",
+       "8        cost           mean  1297.4921       $\n",
+       "9        cost         median  1241.7834       $\n",
+       "10       cost  percentile_20   972.9829       $\n",
+       "11       cost  percentile_80  1554.4402       $"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Convert the baseline from JSON to a pandas data frame for further\n",
     "# analysis.\n",
@@ -226,7 +363,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "5e302eba",
    "metadata": {},
    "outputs": [],
@@ -236,7 +373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "f32a8ed4",
    "metadata": {},
    "outputs": [],
@@ -245,9 +382,130 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "06fd057d-fbc7-470a-b834-18ff9dedae82",
+   "metadata": {},
+   "source": [
+    "## Modeling Water Heater Upgrades\n",
+    "\n",
+    "The `heating_fuel` of a home is always required by `/api/v1/rem/address`. When you request a water heater upgrade, you must also provide the fuel type of the existing water heater in the `water_heater_fuel` parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "e39346ac-4825-4f21-a1e8-74c004629005",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Expected annual savings: $225.26'"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Model a heat pump water heater upgrade\n",
+    "\n",
+    "response = requests.get(\n",
+    "    url=REM_ADDRESS_URL,\n",
+    "    headers=headers,\n",
+    "    params=dict(address=address, upgrade=\"water_heater__heat_pump_uef3.35\", heating_fuel=heating_fuel, water_heater_fuel=\"electricity\"),\n",
+    ")\n",
+    "data = response.json()\n",
+    "annual_savings = -data[\"fuel_results\"][\"total\"][\"delta\"][\"cost\"][\"mean\"][\"value\"]\n",
+    "\n",
+    "f\"Expected annual savings: ${annual_savings:.2f}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41a4aca4-8ebe-4ff0-9631-ac50f02a791a",
+   "metadata": {},
+   "source": [
+    "You can optionally set `water_heater_fuel` for other upgrades as well. This can help make the baseline results more accurate, by restricting the modeled homes to those with water heaters fueled in the same way.\n",
+    "\n",
+    "However, if your water heater fuel type is relatively unusual for homes in your area with your heating fuel type, there is a chance the model won't be able to make a good prediction and you'll get an error message.\n",
+    "\n",
+    "If this happens, we recommend not setting the water heater fuel type when it's not required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "8806810d-aa5f-4fff-b101-63347bff120b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<Response [400]>\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'{\"detail\":\"The current version of this API cannot predict energy savings for the provided address. Omitting water_heater_fuel may help, by allowing more samples to match the characteristics of the provided home.\"}'"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Attempt to model a home with an uncommon heating fuel and water heater fuel combination.\n",
+    "\n",
+    "response = requests.get(\n",
+    "    url=REM_ADDRESS_URL,\n",
+    "    headers=headers,\n",
+    "    # It's very unusual to use propane for home heating with natural gas for water heating.\n",
+    "    params=dict(address=address, upgrade=upgrade, heating_fuel=\"propane\", water_heater_fuel=\"natural_gas\"),\n",
+    ")\n",
+    "\n",
+    "print(response)\n",
+    "\n",
+    "# The error message will let you know if the water heater fuel is likely to be the problem.\n",
+    "response.text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "bc3c5097-c3ad-48bf-85d1-318e79115f53",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Response [200]>"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Omit the water heater fuel to get results.\n",
+    "response = requests.get(\n",
+    "    url=REM_ADDRESS_URL,\n",
+    "    headers=headers,\n",
+    "    params=dict(address=address, upgrade=upgrade, heating_fuel=\"propane\"),\n",
+    ")\n",
+    "\n",
+    "response"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e39346ac-4825-4f21-a1e8-74c004629005",
+   "id": "69ca2263-c886-4aca-a919-c545d9c566b2",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -269,7 +527,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.13.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Add demo examples that show:
- Successfully requesting a water heater upgrade, which requires `water_heater_fuel`
- How an unusual location + heating fuel + water heater fuel combination can lead to not getting any results
  - How unsetting the water heater fuel can help in this case


Note: Tests are failing because the water heater upgrade is not yet in production. I won't merge this PR until the feature is released and these tests pass.