### PR TITLE
Adding `estimate_type` to the API demo's notebook

### DIFF
--- a/notebooks/REM Demo.ipynb
+++ b/notebooks/REM Demo.ipynb
@@ -508,7 +508,7 @@
    "metadata": {},
    "source": [
     "## Estimation Methodology\n",
-    "You may want to understand more about how an estimate was *made*. The `estimate_type` returned in a REM request indicates how we understand a home’s features in order to generate an estimate.\n",
+    "You may want to understand more about the *specificity* of the estimate returned. The `estimate_type` returned in a REM request indicates how much we understand about a home’s features before generating an estimate.\n",
     "\n",
     "There are two potential outputs for `estimate_type`:\n",
     "- `address_level`: The estimate is based on known features specific to the home at that address, enabling a more tailored result.\n",

--- a/notebooks/REM Demo.ipynb
+++ b/notebooks/REM Demo.ipynb
@@ -512,7 +512,7 @@
     "\n",
     "There are two potential outputs for `estimate_type`:\n",
     "- `address_level`: The estimate is based on known features specific to the home at that address, enabling a more tailored result.\n",
-    "- `puma_level`: The estimate is based on typical features of homes within the Census Public Use Microdata Area (PUMA) where the home is located."
+    "- `puma_level`: The estimate is based on the provided heating fuel and typical features of homes within the Census Public Use Microdata Area (PUMA) where the home is located."
    ]
   },
   {

--- a/notebooks/REM Demo.ipynb
+++ b/notebooks/REM Demo.ipynb
@@ -503,6 +503,94 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "bfaaf437",
+   "metadata": {},
+   "source": [
+    "## Estimation Methodology\n",
+    "You may want to understand more about how an estimate was *made*. The `estimate_type` returned in a REM request indicates how we understand a home’s features in order to generate an estimate.\n",
+    "\n",
+    "There are two potential outputs for `estimate_type`:\n",
+    "- `address_level`: The estimate is based on known features specific to the home at that address, enabling a more tailored result.\n",
+    "- `puma_level`: The estimate is based on typical features of homes within the Census Public Use Microdata Area (PUMA) where the home is located."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0d6698e8",
+   "metadata": {},
+   "source": [
+    "### Address-Level Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "e8d35b02",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Performed address-level estimate due to full set of available housing features.\n",
+      "Estimate type: address_level\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "address_with_known_housing_features = \"3126 Russell Street, San Diego, CA 92107\" \n",
+    "\n",
+    "response = requests.get(\n",
+    "    url=REM_ADDRESS_URL,\n",
+    "    headers=headers,\n",
+    "    params=dict(address=address_with_known_housing_features, upgrade=\"hvac__heat_pump_seer18_hspf10\", heating_fuel=heating_fuel),\n",
+    ")\n",
+    "data = response.json()\n",
+    "estimate_type = data[\"estimate_type\"]\n",
+    "\n",
+    "print(f\"Performed address-level estimate due to full set of available housing features.\\nEstimate type: {estimate_type}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f32f016a",
+   "metadata": {},
+   "source": [
+    "### PUMA-level Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "096657fa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PUMA-level estimate performed due to limited housing feature data.\n",
+      "Estimate type: puma_level\n"
+     ]
+    }
+   ],
+   "source": [
+    "address_with_limited_known_housing_features = \"1382 US-67 Stephenville, TX 76401\"\n",
+    "\n",
+    "response = requests.get(\n",
+    "    url=REM_ADDRESS_URL,\n",
+    "    headers=headers,\n",
+    "    params=dict(address=address_with_limited_known_housing_features, upgrade=\"hvac__heat_pump_seer18_hspf10\", heating_fuel=heating_fuel),\n",
+    ")\n",
+    "data = response.json()\n",
+    "estimate_type = data[\"estimate_type\"]\n",
+    "\n",
+    "print(f\"PUMA-level estimate performed due to limited housing feature data.\\nEstimate type: {estimate_type}\")"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "69ca2263-c886-4aca-a919-c545d9c566b2",


### PR DESCRIPTION
# Overview
Added a feature explanation and two examples for the new `estimate_type` field in REM. 

## Issue Ticket
[Ticket](https://rewiringamerica.atlassian.net/browse/RAT-675?atlOrigin=eyJpIjoiNWQyMWY0NTNlZjI1NGUyNjk2ZGNhMDI0MzM4MGNlODUiLCJwIjoiaiJ9)

## Change Type
feature

## Implementation Notes
Added two basic REM requests using two addresses we know that perform their estimates on different geographic levels.

## Test Plan
Ran the notebook locally and saw that the `estimate_type` for each use case (`address_level` & `puma_level`) matched the examples.