### PR TITLE
Adding percentile ratio to show the percision between the estimate ty…

### DIFF
--- a/notebooks/REM Demo.ipynb
+++ b/notebooks/REM Demo.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "27e49c93-57d7-4ee9-bb54-623b50e4e87c",
    "metadata": {},
    "outputs": [],
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "cecd5ef2-6a34-4752-9899-fc3fe519c3d9",
    "metadata": {},
    "outputs": [],
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "654ba342-e8d5-480b-9bcc-cd9e226b1122",
    "metadata": {},
    "outputs": [],
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "58f2da86-6a32-448d-83a5-ba487e6c54a8",
    "metadata": {},
    "outputs": [],
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "2aa2f974-6382-45db-9b8a-bc127873f924",
    "metadata": {},
    "outputs": [],
@@ -112,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "90889101-3961-4c23-841c-f6bfb994cee1",
    "metadata": {},
    "outputs": [],
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "6aab1b8e-c3d9-4d0f-a7d4-1a86f1543def",
    "metadata": {
     "scrolled": true
@@ -131,10 +131,10 @@
     {
      "data": {
       "text/plain": [
-       "'Expected annual savings: $659.07'"
+       "'Expected annual savings: $681.78'"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -164,7 +164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "d697ac84",
    "metadata": {},
    "outputs": [],
@@ -190,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "1831a4bd",
    "metadata": {},
    "outputs": [],
@@ -201,7 +201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "cf88eec5",
    "metadata": {},
    "outputs": [
@@ -237,84 +237,84 @@
        "      <th>0</th>\n",
        "      <td>energy</td>\n",
        "      <td>mean</td>\n",
-       "      <td>818.0488</td>\n",
+       "      <td>803.1256</td>\n",
        "      <td>therm</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>energy</td>\n",
        "      <td>median</td>\n",
-       "      <td>773.5015</td>\n",
+       "      <td>770.1843</td>\n",
        "      <td>therm</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>energy</td>\n",
        "      <td>percentile_20</td>\n",
-       "      <td>558.5560</td>\n",
+       "      <td>562.2991</td>\n",
        "      <td>therm</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>energy</td>\n",
        "      <td>percentile_80</td>\n",
-       "      <td>1023.5165</td>\n",
+       "      <td>993.4048</td>\n",
        "      <td>therm</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>emissions</td>\n",
        "      <td>mean</td>\n",
-       "      <td>5464.4159</td>\n",
+       "      <td>5364.7319</td>\n",
        "      <td>kgCO2e</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
        "      <td>emissions</td>\n",
        "      <td>median</td>\n",
-       "      <td>5166.8484</td>\n",
+       "      <td>5144.6899</td>\n",
        "      <td>kgCO2e</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
        "      <td>emissions</td>\n",
        "      <td>percentile_20</td>\n",
-       "      <td>3731.0518</td>\n",
+       "      <td>3756.0548</td>\n",
        "      <td>kgCO2e</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
        "      <td>emissions</td>\n",
        "      <td>percentile_80</td>\n",
-       "      <td>6836.9028</td>\n",
+       "      <td>6635.7620</td>\n",
        "      <td>kgCO2e</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
        "      <td>cost</td>\n",
        "      <td>mean</td>\n",
-       "      <td>1297.4921</td>\n",
+       "      <td>1278.8299</td>\n",
        "      <td>$</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
        "      <td>cost</td>\n",
        "      <td>median</td>\n",
-       "      <td>1241.7834</td>\n",
+       "      <td>1237.6351</td>\n",
        "      <td>$</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>10</th>\n",
        "      <td>cost</td>\n",
        "      <td>percentile_20</td>\n",
-       "      <td>972.9829</td>\n",
+       "      <td>977.6638</td>\n",
        "      <td>$</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>11</th>\n",
        "      <td>cost</td>\n",
        "      <td>percentile_80</td>\n",
-       "      <td>1554.4402</td>\n",
+       "      <td>1516.7839</td>\n",
        "      <td>$</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -323,21 +323,21 @@
       ],
       "text/plain": [
        "       metric           stat      value    unit\n",
-       "0      energy           mean   818.0488   therm\n",
-       "1      energy         median   773.5015   therm\n",
-       "2      energy  percentile_20   558.5560   therm\n",
-       "3      energy  percentile_80  1023.5165   therm\n",
-       "4   emissions           mean  5464.4159  kgCO2e\n",
-       "5   emissions         median  5166.8484  kgCO2e\n",
-       "6   emissions  percentile_20  3731.0518  kgCO2e\n",
-       "7   emissions  percentile_80  6836.9028  kgCO2e\n",
-       "8        cost           mean  1297.4921       $\n",
-       "9        cost         median  1241.7834       $\n",
-       "10       cost  percentile_20   972.9829       $\n",
-       "11       cost  percentile_80  1554.4402       $"
+       "0      energy           mean   803.1256   therm\n",
+       "1      energy         median   770.1843   therm\n",
+       "2      energy  percentile_20   562.2991   therm\n",
+       "3      energy  percentile_80   993.4048   therm\n",
+       "4   emissions           mean  5364.7319  kgCO2e\n",
+       "5   emissions         median  5144.6899  kgCO2e\n",
+       "6   emissions  percentile_20  3756.0548  kgCO2e\n",
+       "7   emissions  percentile_80  6635.7620  kgCO2e\n",
+       "8        cost           mean  1278.8299       $\n",
+       "9        cost         median  1237.6351       $\n",
+       "10       cost  percentile_20   977.6638       $\n",
+       "11       cost  percentile_80  1516.7839       $"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -363,7 +363,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "5e302eba",
    "metadata": {},
    "outputs": [],
@@ -373,7 +373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "f32a8ed4",
    "metadata": {},
    "outputs": [],
@@ -393,17 +393,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "e39346ac-4825-4f21-a1e8-74c004629005",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'Expected annual savings: $225.26'"
+       "'Expected annual savings: $206.80'"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -436,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "8806810d-aa5f-4fff-b101-63347bff120b",
    "metadata": {},
    "outputs": [
@@ -450,10 +450,10 @@
     {
      "data": {
       "text/plain": [
-       "'{\"detail\":\"The current version of this API cannot predict energy savings for the provided address. Omitting water_heater_fuel may help, by allowing more samples to match the characteristics of the provided home.\"}'"
+       "'{\"detail\":{\"type\":\"building_not_supported\",\"msg\":\"The current version of this API cannot predict energy savings for the provided address. Omitting water_heater_fuel may help, by allowing more samples to match the characteristics of the provided home.\"}}'"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -476,7 +476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 56,
    "id": "bc3c5097-c3ad-48bf-85d1-318e79115f53",
    "metadata": {},
    "outputs": [
@@ -486,7 +486,7 @@
        "<Response [200]>"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -512,7 +512,9 @@
     "\n",
     "There are two potential outputs for `estimate_type`:\n",
     "- `address_level`: The estimate is based on known features specific to the home at that address, enabling a more tailored result.\n",
-    "- `puma_level`: The estimate is based on the provided heating fuel and typical features of homes within the Census Public Use Microdata Area (PUMA) where the home is located."
+    "- `puma_level`: The estimate is based on the provided heating fuel and typical features of homes within the Census Public Use Microdata Area (PUMA) where the home is located.\n",
+    "\n",
+    "The difference in precision between these two can be observed in the ratio between `percentile_80` and `percentile_20` where the `address-level` estimates will have a smaller ratio than the `puma-level` estimates."
    ]
   },
   {
@@ -525,7 +527,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 57,
    "id": "e8d35b02",
    "metadata": {},
    "outputs": [
@@ -554,6 +556,32 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b62c0c2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "80th percentile: 2104.93 kgCO2e\n",
+      "20th percentile: 823.39 kgCO2e\n",
+      "Observed ratio: 2.56\n"
+     ]
+    }
+   ],
+   "source": [
+    "percentile_80 = data[\"fuel_results\"][\"natural_gas\"][\"upgrade\"][\"emissions\"][\"percentile_80\"][\"value\"]\n",
+    "percentile_20 = data[\"fuel_results\"][\"natural_gas\"][\"upgrade\"][\"emissions\"][\"percentile_20\"][\"value\"]\n",
+    "percentile_ratio = percentile_80 / percentile_20\n",
+    "\n",
+    "# A smaller ratio means estimates are more precise.\n",
+    "print(f\"80th percentile: {percentile_80:.2f} kgCO2e\\n20th percentile: {percentile_20:.2f} kgCO2e\")\n",
+    "print(f\"Observed ratio: {percentile_ratio:.2f}\")\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "f32f016a",
    "metadata": {},
@@ -563,7 +591,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 59,
    "id": "096657fa",
    "metadata": {},
    "outputs": [
@@ -587,21 +615,40 @@
     "data = response.json()\n",
     "estimate_type = data[\"estimate_type\"]\n",
     "\n",
+    "\n",
     "print(f\"PUMA-level estimate performed due to limited housing feature data.\\nEstimate type: {estimate_type}\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69ca2263-c886-4aca-a919-c545d9c566b2",
+   "id": "c891570c",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "80th percentile: 1304.73 kgCO2e\n",
+      "20th percentile: 357.85 kgCO2e\n",
+      "Observed ratio: 3.65\n"
+     ]
+    }
+   ],
+   "source": [
+    "percentile_80 = data[\"fuel_results\"][\"natural_gas\"][\"upgrade\"][\"emissions\"][\"percentile_80\"][\"value\"]\n",
+    "percentile_20 = data[\"fuel_results\"][\"natural_gas\"][\"upgrade\"][\"emissions\"][\"percentile_20\"][\"value\"]\n",
+    "percentile_ratio = percentile_80 / percentile_20 # In kgCO2e\n",
+    "\n",
+    "# Larger ratio means estimates have more uncertaintity or variability\n",
+    "print(f\"80th percentile: {percentile_80:.2f} kgCO2e\\n20th percentile: {percentile_20:.2f} kgCO2e\")\n",
+    "print(f\"Observed ratio: {percentile_ratio:.2f}\")"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv (3.11.10)",
    "language": "python",
    "name": "python3"
   },
@@ -615,7 +662,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.1"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Overview
Follow-up to the previous PR that introduced an `estimate_type` by adding the use of `percentile_80` and `percentile_20` to showcase the difference in precision of our predictions using the two different estimation methods. 

## Issue Ticket
Follow-up to this [PR comment](https://github.com/rewiringamerica/api_demos/pull/25#discussion_r2246479184).

## Change Type
feature

## Implementation Notes
I used the ratio instead of width to highlight differences between estimate types. Since we’re not comparing the exact same home, raw widths can be misleading to me. The ratio felt like a clearer, more comparable metric. Let me know your thoughts on this!

## Test Plan
Ran notebook.
